### PR TITLE
Add method for adding form errors manually.

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -215,6 +215,11 @@ abstract class FormModel implements FormModelInterface
         return !$this->hasErrors();
     }
 
+    public function addError(string $attribute, string $error): void
+    {
+        $this->attributesErrors[$attribute][] = $error;
+    }
+
     private function addErrors(array $items): void
     {
         foreach ($items as $attribute => $errors) {

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -78,6 +78,14 @@ interface FormModelInterface extends DataSetInterface
     public function isAttributeRequired(string $attribute): bool;
 
     /**
+     * Add error for the specified attribute.
+     *
+     * @param string $attribute attribute name.
+     * @param string $error attribute error message.
+     */
+    public function addError(string $attribute, string $error): void;
+
+    /**
      * Returns the errors for all attributes.
      *
      * @return array errors for all attributes or the specified attribute. null is returned if no error.

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -7,6 +7,8 @@ namespace Yiisoft\Yii\Form\Tests;
 use InvalidArgumentException;
 use Yiisoft\Yii\Form\Tests\Stub\LoginForm;
 
+use function str_repeat;
+
 final class FormModelTest extends TestCase
 {
     public function testGetFormName(): void
@@ -171,7 +173,7 @@ final class FormModelTest extends TestCase
             $form->error('login')
         );
 
-        $form->login(\str_repeat('x', 60));
+        $form->login(str_repeat('x', 60));
         $form->validate();
         $this->assertEquals(
             'Is too long.',

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -130,6 +130,17 @@ final class FormModelTest extends TestCase
         $this->assertEquals(true, $form->getRememberMe());
     }
 
+    public function testAddError(): void
+    {
+        $form = new LoginForm();
+        $errorMessage = 'Invalid password.';
+
+        $form->addError('password', $errorMessage);
+
+        $this->assertTrue($form->hasErrors());
+        $this->assertEquals($errorMessage, $form->firstError('password'));
+    }
+
     public function testValidatorRules(): void
     {
         $form = new LoginForm();

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -141,6 +141,17 @@ final class FormModelTest extends TestCase
         $this->assertEquals($errorMessage, $form->firstError('password'));
     }
 
+    public function testAddAndGetErrorForNonExistingAttribute(): void
+    {
+        $form = new LoginForm();
+        $errorMessage = 'Invalid username and/or password.';
+
+        $form->addError('form', $errorMessage);
+
+        $this->assertTrue($form->hasErrors());
+        $this->assertEquals($errorMessage, $form->firstError('form'));
+    }
+
     public function testValidatorRules(): void
     {
         $form = new LoginForm();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Adds an ability to add errors to the form manually. The use case is when you do some external validation (that is not in rules) such as validating password with database value (I prefer not to place db dependencies in `FormModel` and do validation manually in some service).
